### PR TITLE
Documentation Fix: Change build step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The build target manages dependencies, builds required assets (e.g. packaged lam
 AWS CloudFormation templates for all modules.
 
 ```bash
-make build
+make build-all
 ```
 
 ### Upload Assets to S3


### PR DESCRIPTION
**Issue #, if available:**
When following the steps from the readme file to install the CMS Solution, an error occurs during the `make upload` because the resources are not available.

This is due to the fact that only a `make build` was executed instead of a `make build-all`. This has been fixed with this PR.

**Description of changes:**
Change the build step from `make build` to `make build-all`


**Checklist**
- [x] :wave: I have added unit tests for all code changes. (not applicable)
- [x] :wave: I have run the unit tests, and all unit tests have passed. (not applicable)
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Greetings from Storm Reply Germany as well 
