### PR TITLE
fix: reorder find command options to avoid warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(lastword $(subst /, ,$2))-$1:
 	@$(MAKE) -C $2 -f Makefile $1
 endef
 
-MODULES := source/lib $(shell find ${SOLUTION_PATH}/source/modules -type d -maxdepth 1 -mindepth 1 -not -name __pycache__)
+MODULES := source/lib $(shell find ${SOLUTION_PATH}/source/modules -maxdepth 1 -mindepth 1 -type d -not -name __pycache__)
 GLOBAL_TARGETS := $(shell grep -E '^[a-zA-Z0-9-]+:' ${SOLUTION_PATH}/makefiles/global_targets.mk | awk -F: '/^[^.]/ {print $$1;}')
 MODULE_TARGETS := $(shell grep -E '^[a-zA-Z0-9-]+:' ${SOLUTION_PATH}/makefiles/module_targets.mk | awk -F: '/^[^.]/ {print $$1;}')
 


### PR DESCRIPTION
Changed the order of find command options in Makefile to follow GNU find's recommended pattern, placing filter options (-maxdepth, -mindepth) before test options (-type). This change eliminates warnings that could appear with find command.

#### Issue #, if available
There is no Issue.

#### Description of changes
Whenever I run a make-related command, such as make help, I get the following warning
```
find: warning: you have specified the global option -maxdepth after the argument -type, but global options are not positional, i.e., -maxdepth affects Please specify global options before other arguments.
```
So I changed the order of options in the find command. After the change, warnings are not output.

#### Checklist

- [x] :wave: I have added unit tests for all code changes. **(Not applicable: This is a Makefile change.)**
- [x] :wave: I have run the unit tests, and all unit tests have passed. **(Not applicable: No code logic changes.)**
- [x] :warning: This pull request might incur a breaking change. **(Not applicable: This change does not introduce breaking changes.)**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
