### PR TITLE
release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2025-04-21
+
+### Fixed
+
+- Fix s3 copy cdk construct running out of memory
+- Remove 'United States' region constraint on the Vehicle Simulator Cloudfront Distribution
+to allow other regions to use it out of the box.
+- Update shell find arg order to fix warnings
+
 ## [2.1.1] - 2025-04-03
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ $(lastword $(subst /, ,$2))-$1:
 	@$(MAKE) -C $2 -f Makefile $1
 endef
 
-MODULES := source/lib $(shell find ${SOLUTION_PATH}/source/modules -type d -maxdepth 1 -mindepth 1 -not -name __pycache__)
+MODULES := source/lib $(shell find ${SOLUTION_PATH}/source/modules -maxdepth 1 -mindepth 1 -type d -not -name __pycache__)
 GLOBAL_TARGETS := $(shell grep -E '^[a-zA-Z0-9-]+:' ${SOLUTION_PATH}/makefiles/global_targets.mk | awk -F: '/^[^.]/ {print $$1;}')
 MODULE_TARGETS := $(shell grep -E '^[a-zA-Z0-9-]+:' ${SOLUTION_PATH}/makefiles/module_targets.mk | awk -F: '/^[^.]/ {print $$1;}')
 

--- a/makefiles/common_config.mk
+++ b/makefiles/common_config.mk
@@ -15,7 +15,7 @@ export AWS_REGION ?= ${DEFAULTS.AWS_REGION}
 # ========================================================
 export SOLUTION_NAME ?= connected-mobility-solution-on-aws
 export SOLUTION_DESCRIPTION ?= Accelerate development and deployment of connected vehicle assets with purpose-built, deployment-ready accelerators, and an Automotive Cloud Developer Portal
-export SOLUTION_VERSION ?= v2.1.1
+export SOLUTION_VERSION ?= v2.1.2
 export SOLUTION_AUTHOR = AWS Industrial Solutions Team
 export SOLUTION_ID = SO0241
 # Path is relative to this file's location, moving this file requires updating this path.

--- a/source/lib/setup.py
+++ b/source/lib/setup.py
@@ -52,7 +52,7 @@ setup(
         "toml>=0.10.2",
     ],
     name="cms_common",
-    version="2.1.1",
+    version="2.1.2",
     description="Common library used in CMS modules",
     packages=find_packages(
         exclude=[

--- a/source/modules/backstage/cdk/source/tests/infrastructure/__snapshots__/test_snapshot/test_acdp_backstage_snapshot.json
+++ b/source/modules/backstage/cdk/source/tests/infrastructure/__snapshots__/test_snapshot/test_acdp_backstage_snapshot.json
@@ -1192,7 +1192,7 @@
               },
               {
                 "Name": "SOLUTION_VERSION",
-                "Value": "v2.1.1"
+                "Value": "v2.1.2"
               },
               {
                 "Name": "SOLUTION_ID",

--- a/source/modules/backstage/package.json
+++ b/source/modules/backstage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acdp-backstage",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "Apache-2.0",
   "description": "Backstage implementation preconfigured to work with CMS",

--- a/source/modules/backstage/packages/app/package.json
+++ b/source/modules/backstage/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "bundled": true,
   "license": "Apache-2.0",

--- a/source/modules/backstage/packages/backend/package.json
+++ b/source/modules/backstage/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/source/modules/backstage/plugins/acdp-backend/package.json
+++ b/source/modules/backstage/plugins/acdp-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backstage-plugin-acdp-backend",
   "description": "ACDP Backend plugin for Backstage",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/acdp-common/package.json
+++ b/source/modules/backstage/plugins/acdp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backstage-plugin-acdp-common",
   "description": "Common interfaces for ACDP plugins",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/acdp-partner-offering/package.json
+++ b/source/modules/backstage/plugins/acdp-partner-offering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-acdp-partner-offering",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/acdp/package.json
+++ b/source/modules/backstage/plugins/acdp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backstage-plugin-acdp",
   "description": "ACDP plugin for Backstage",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/auth-oauth2-provider-module/package.json
+++ b/source/modules/backstage/plugins/auth-oauth2-provider-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auth-oauth2-provider-module",
   "description": "The oauth2-provider backend module for the auth plugin.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/catalog-acdp-partner-offering-backend-module/package.json
+++ b/source/modules/backstage/plugins/catalog-acdp-partner-offering-backend-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "catalog-acdp-partner-offering-backend-module",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/backstage/plugins/techdocs-custom-build-strategy-module/package.json
+++ b/source/modules/backstage/plugins/techdocs-custom-build-strategy-module/package.json
@@ -1,7 +1,7 @@
 {
   "name": "techdocs-custom-build-strategy-module",
   "description": "The custom-build-strategy backend module for the techdocs plugin.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/source/modules/cms_vehicle_simulator/source/infrastructure/constructs/cloudfront.py
+++ b/source/modules/cms_vehicle_simulator/source/infrastructure/constructs/cloudfront.py
@@ -112,7 +112,6 @@ class CloudFrontConstruct(Construct):
             ),
             cloud_front_distribution_props={
                 "comment": "CMS Vehicle Simulator Distribution",
-                "geoRestriction": aws_cloudfront.GeoRestriction.allowlist("US"),
                 "enableLogging": True,
                 "minimumProtocolVersion": aws_cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
                 "httpVersion": aws_cloudfront.HttpVersion.HTTP2,

--- a/source/modules/cms_vehicle_simulator/source/infrastructure/constructs/console.py
+++ b/source/modules/cms_vehicle_simulator/source/infrastructure/constructs/console.py
@@ -287,6 +287,7 @@ class ConsoleConstruct(Construct):
             exclude=["aws_config.js"],
             destination_bucket=source_code_bucket,
             prune=False,
+            memory_limit=1024,
             vpc=vpc_construct.vpc,
             vpc_subnets=vpc_construct.private_subnet_selection,
         )

--- a/source/modules/cms_vehicle_simulator/source/tests/infrastructure/__snapshots__/test_snapshot/test_cms_vehicle_simulator_snapshot.json
+++ b/source/modules/cms_vehicle_simulator/source/tests/infrastructure/__snapshots__/test_snapshot/test_cms_vehicle_simulator_snapshot.json
@@ -581,10 +581,10 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edD2E1BB5D": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147ed9D24310A": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC7A8FAB8",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleD28B42C0"
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC5A99A56",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRole51FAA157"
       ],
       "Properties": {
         "Code": {
@@ -604,9 +604,10 @@
             "Ref": "cmsvehiclesimulatorconsoleconstructconsolebucketdeploymentAwsCliLayer0549F181"
           }
         ],
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleD28B42C0",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRole51FAA157",
             "Arn"
           ]
         },
@@ -627,7 +628,7 @@
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [
-                "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edSecurityGroup376015AC",
+                "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edSecurityGroupDC46EAE6",
                 "GroupId"
               ]
             }
@@ -668,9 +669,9 @@
       },
       "Type": "AWS::Lambda::Function"
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edSecurityGroup376015AC": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edSecurityGroupDC46EAE6": {
       "Properties": {
-        "GroupDescription": "Automatic security group for Lambda Function cmsvehiclesimulatorstackCustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147ed0A0CC3E9",
+        "GroupDescription": "Automatic security group for Lambda Function cmsvehiclesimulatorstackCustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edC218D4D7",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
@@ -707,7 +708,7 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleD28B42C0": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRole51FAA157": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -761,7 +762,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC7A8FAB8": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC5A99A56": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -846,10 +847,10 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "tomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC7A8FAB8",
+        "PolicyName": "ucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleDefaultPolicyC5A99A56",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRoleD28B42C0"
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147edServiceRole51FAA157"
           }
         ]
       },
@@ -2332,15 +2333,7 @@
                 "OriginAccessIdentity": ""
               }
             }
-          ],
-          "Restrictions": {
-            "GeoRestriction": {
-              "Locations": [
-                "US"
-              ],
-              "RestrictionType": "whitelist"
-            }
-          }
+          ]
         },
         "Tags": [
           {
@@ -3197,7 +3190,7 @@
       },
       "Type": "AWS::Lambda::LayerVersion"
     },
-    "cmsvehiclesimulatorconsoleconstructconsolebucketdeploymentCustomResourcec8c0dea6cecbd0731e114013b423c54e1adb1147edB1C22DD3": {
+    "cmsvehiclesimulatorconsoleconstructconsolebucketdeploymentCustomResource1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147ed5ACAAFBA": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "ssmappuniqueidregistermodule9C5C2C5D"
@@ -3236,7 +3229,7 @@
         "Prune": false,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756Cc8c0dea6cecbd0731e114013b423c54e1adb1147edD2E1BB5D",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C1024MiBc8c0dea6cecbd0731e114013b423c54e1adb1147ed9D24310A",
             "Arn"
           ]
         },

--- a/source/modules/vpc/source/template.yaml
+++ b/source/modules/vpc/source/template.yaml
@@ -1,7 +1,7 @@
 
 
 AWSTemplateFormatVersion: "2010-09-09"
-Description: (SO0241-CMS.23) connected-mobility-solution-on-aws - vpc. Version v2.1.1
+Description: (SO0241-CMS.23) connected-mobility-solution-on-aws - vpc. Version v2.1.2
   This template deploys a VPC, with a pair of public and private subnets spread
   across two Availability Zones. It deploys an internet gateway, with a default
   route on the public subnets. It deploys a pair of NAT gateways (one in each AZ),


### PR DESCRIPTION
## [2.1.2] - 2025-04-21

### Fixed

- Fix s3 copy cdk construct running out of memory
- Remove 'United States' region constraint on the Vehicle Simulator Cloudfront Distribution
to allow other regions to use it out of the box.
- Update shell find arg order to fix warnings
