### PR TITLE
fix: correct file paths in README customization section

### DIFF
--- a/source/modules/cms_ev_battery_health/README.md
+++ b/source/modules/cms_ev_battery_health/README.md
@@ -201,9 +201,9 @@ Follow the instructions for Step 1 and Step 2 in the AWS IAM Identity Center
 ## Customizing the Solution
 
 1. Customizing the dashboard: add/remove panels in the `create_ev_battery_health_dashboard`
-function [here](./source/handlers/custom_resource/lib/dashboards.py)
+function [here](./source/handlers/custom_resource/function/lib/dashboards.py)
 1. Customizing the alerts: add/remove alert rules in the `create_ev_battery_health_alert_rule_group`
-function [here](./source/handlers/custom_resource/lib/alerts.py)
+function [here](./source/handlers/custom_resource/function/lib/alerts.py)
 
 ## Securing the Solution
 


### PR DESCRIPTION
Update file path references in customization instructions to include missing '/function/' directory in the path structure.

#### Issue #, if available
There are no corresponding issues.

#### Description of changes
There were some broken links in the README, so I corrected them to the appropriate paths.

#### Checklist

- [N/A] :wave: I have added unit tests for all code changes.
- [N/A] :wave: I have run the unit tests, and all unit tests have passed.
- [N/A] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
